### PR TITLE
Add HubSpot Village Form To /Villages Page

### DIFF
--- a/src/app/villages/page.jsx
+++ b/src/app/villages/page.jsx
@@ -13,8 +13,8 @@ export default function Villages() {
       />
 
       <div className="max-w-5xl mx-auto wrapper-pages p-4 md:mb-12 pt-4 -mt-12">
-        <div class="hs-form-frame mt-6 mb-14" data-region="na2" data-form-id="fb4869ea-c35c-4d70-9ddb-7508f9d6cf1f" data-portal-id="242985282">
+        <div className="hs-form-frame mt-6 mb-14" data-region="na2" data-form-id="fb4869ea-c35c-4d70-9ddb-7508f9d6cf1f" data-portal-id="242985282"></div>
       </div>
     </main>
-  )
+  );
 }


### PR DESCRIPTION
This pull request makes a minor fix to the `Villages` page component. The most notable change is updating the `div` containing the form to use the correct React `className` attribute instead of the HTML `class` attribute.

* Changed the `div` for the form from using `class` to `className` to ensure proper styling and avoid React warnings in `src/app/villages/page.jsx`.

Updated the village page layout and removed old signup content. This embeds HubSpot form to the page directly.